### PR TITLE
Field updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     ],
     "require": {
         "dnadesign/silverstripe-elemental": "^4.3.0",
-        "bummzack/sortablefile" : "^2.1"
+        "bummzack/sortablefile" : "^2.1",
+        "purplespider/asset-alt-text": "^1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 | ^7",

--- a/src/Models/Elements/ElementQuickGallery.php
+++ b/src/Models/Elements/ElementQuickGallery.php
@@ -11,6 +11,7 @@ use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DataList;
 
 /**
  * ElementQuickGallery adds a gallery via a sortable upload field
@@ -55,22 +56,36 @@ class ElementQuickGallery extends ElementContent {
     ];
 
     private static $allowed_file_types = ["jpg","jpeg","gif","png","webp"];
-    private static $default_thumb_width = 128;
-    private static $default_thumb_height = 96;
+
+    /**
+     * @var int
+     */
+    private static $default_thumb_width = 375;
+
+    /**
+     * @var int
+     */
+    private static $default_thumb_height = 282;
 
     public function getType()
     {
         return _t(__CLASS__ . '.BlockType', 'Quick Gallery');
     }
 
+    /**
+     * Return the generated thumbnail width, use in templates if you want to rely on the configured default width value
+     */
     public function getThumbWidth() {
-        $width = $this->Width;
+        return $this->Width;
         if($width <= 0) {
             $width = $this->config()->get('default_thumb_width');
         }
         return $width;
     }
 
+    /**
+     * Return the generated thumbnail height, use in templates if you want to rely on the configured default height value
+     */
     public function getThumbHeight() {
         $height = $this->Height;
         if($height <= 0) {
@@ -88,11 +103,23 @@ class ElementQuickGallery extends ElementContent {
         return $types;
     }
 
+    /**
+     * Ensure a sane dimension is set
+     */
     public function onBeforeWrite()
     {
         parent::onBeforeWrite();
-        $this->Width = $this->getThumbWidth();
-        $this->Height = $this->getThumbHeight();
+
+        // integers only
+        $this->Width = round($this->Width);
+        $this->Height = round($this->Height);
+
+        if($this->Width < 0) {
+            $this->Width = 0;
+        }
+        if($this->Height < 0) {
+            $this->Height = 0;
+        }
     }
 
     public function getCMSFields() {
@@ -101,7 +128,7 @@ class ElementQuickGallery extends ElementContent {
                 'Images'
             ]);
             $fields->addFieldsToTab(
-                'Root.Main', [
+                'Root.Settings', [
                     DropdownField::create(
                         'GalleryType',
                         _t(
@@ -109,8 +136,9 @@ class ElementQuickGallery extends ElementContent {
                             'Gallery type'
                         ),
                         [
-                            'grid' => 'Grid',
-                            'Carousel' => 'Carousel'
+                            'grid' => _t(__CLASS__ . '.GRID_OF_IMAGES','Grid of images'),
+                            'slideshow' => _t(__CLASS__ . '.SLIDESHOW', 'Slideshow'),
+                            'Carousel' => _t(__CLASS__ . '.CAROUSEL_DEPRECATED', 'Carousel - deprecated - (note: https://shouldiuseacarousel.com/)'),
                         ]
                     )->setEmptyString('none'),
                     CheckboxField::create(
@@ -131,7 +159,12 @@ class ElementQuickGallery extends ElementContent {
                         _t(
                             __CLASS__ . 'WIDTH', 'Thumbnail height'
                         )
-                    ),
+                    )
+                ]
+            );
+
+            $fields->addFieldsToTab(
+                'Root.Main', [
                     SortableUploadField::create(
                         'Images',
                         _t(
@@ -148,6 +181,7 @@ class ElementQuickGallery extends ElementContent {
                     )
                 ]
             );
+
         });
         return parent::getCMSFields();
     }
@@ -155,7 +189,7 @@ class ElementQuickGallery extends ElementContent {
     /**
      * Return images in sorted order
      */
-    public function SortedImages() {
+    public function SortedImages() : DataList {
         return $this->Images()->Sort('SortOrder');
     }
 }

--- a/src/Models/Elements/ElementQuickGallery.php
+++ b/src/Models/Elements/ElementQuickGallery.php
@@ -76,7 +76,7 @@ class ElementQuickGallery extends ElementContent {
      * Return the generated thumbnail width, use in templates if you want to rely on the configured default width value
      */
     public function getThumbWidth() {
-        return $this->Width;
+        $width = $this->Width;
         if($width <= 0) {
             $width = $this->config()->get('default_thumb_width');
         }

--- a/src/Models/Elements/ElementQuickGallery.php
+++ b/src/Models/Elements/ElementQuickGallery.php
@@ -151,13 +151,13 @@ class ElementQuickGallery extends ElementContent {
                     NumericField::create(
                         'Width',
                         _t(
-                            __CLASS__ . 'WIDTH', 'Thumbnail width'
+                            __CLASS__ . '.WIDTH', 'Thumbnail width'
                         )
                     ),
                     NumericField::create(
                         'Height',
                         _t(
-                            __CLASS__ . 'WIDTH', 'Thumbnail height'
+                            __CLASS__ . '.HEIGHT', 'Thumbnail height'
                         )
                     )
                 ]
@@ -175,7 +175,7 @@ class ElementQuickGallery extends ElementContent {
                     ->setAllowedExtensions($this->getAllowedFileTypes())
                     ->setDescription(
                         sprintf(_t(
-                            __CLASS__ . 'ALLOWED_FILE_TYPES',
+                            __CLASS__ . '.ALLOWED_FILE_TYPES',
                             'Allowed file types: %s'
                         ), implode(",", $this->getAllowedFileTypes()))
                     )


### PR DESCRIPTION
## Changes

+ Allow zero width/height fields, this allows templates to specify their own width/height
+ Increase default thumbnails width and and height
+ Add `purplespider/asset-alt-text` as a dependency
+ Clear up i18n strings
+ Mark carousel option deprecated