### PR TITLE
Configurable frontend for loading gallery

### DIFF
--- a/src/Controllers/ElementQuickGalleryController.php
+++ b/src/Controllers/ElementQuickGalleryController.php
@@ -1,51 +1,14 @@
 <?php
-namespace NSWDPC\Elemental\Models\QuickGallery;
+namespace NSWDPC\Elemental\Controllers\QuickGallery;
 
 use DNADesign\Elemental\Controllers\ElementController;
-use SilverStripe\View\Requirements;
-use SilverStripe\View\ThemeResourceLoader;
+use NSWDPC\Elemental\Services\QuickGallery\Frontend;
 
 class ElementQuickGalleryController extends ElementController
 {
     public function init() {
-
         parent::init();
-        if ($this->owner->UseJS) {
-            Requirements::javascript(
-                'https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js',
-                [
-                    "integrity" => "sha512-XtmMtDEcNz2j7ekrtHvOVR4iwwaD6o/FUJe6+Zq+HgcCsk3kj4uSQQR8weQ2QVj1o0Pk6PwYLohm206ZzNfubg==",
-                    "crossorigin" => "anonymous"
-                ]
-            );
-            Requirements::javascript(
-                'https://cdnjs.cloudflare.com/ajax/libs/slick-lightbox/0.2.12/slick-lightbox.min.js',
-                [
-                    "integrity" => "sha512-iSVaq9Huv1kxBDAOH7Il1rwIJD+uspMQC1r4Y73QquhbI2ia+PIXUoS5rBjWjYyD03S8t7gZmON+Dk6yPlWHXw==",
-                    "crossorigin" => "anonymous"
-                ]
-            );
-
-
-            Requirements::css('https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.css');
-            Requirements::css('https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick-theme.min.css');
-            Requirements::css('https://cdnjs.cloudflare.com/ajax/libs/slick-lightbox/0.2.12/slick-lightbox.css');
-
-
-
-            Requirements::customScript(
-<<<JS
-    $(document).ready(function(){
-        $('.gallery').slickLightbox({
-            itemSelector: 'a.gallery-item'
-        });
-    });
-JS
-            );
-
-        }
-
-
+        Frontend::create()->addRequirements($this->getElement());
     }
-}
 
+}

--- a/src/Models/Elements/ElementQuickGallery.php
+++ b/src/Models/Elements/ElementQuickGallery.php
@@ -80,7 +80,7 @@ class ElementQuickGallery extends ElementContent {
      * Return the generated thumbnail width, use in templates if you want to rely on the configured default width value
      */
     public function getThumbWidth() {
-        return $this->Width;
+        $width = $this->Width;
         if($width <= 0) {
             $width = $this->config()->get('default_thumb_width');
         }

--- a/src/Models/Elements/ElementQuickGallery.php
+++ b/src/Models/Elements/ElementQuickGallery.php
@@ -162,13 +162,13 @@ class ElementQuickGallery extends ElementContent {
                     NumericField::create(
                         'Width',
                         _t(
-                            __CLASS__ . 'WIDTH', 'Thumbnail width'
+                            __CLASS__ . '.WIDTH', 'Thumbnail width'
                         )
                     ),
                     NumericField::create(
                         'Height',
                         _t(
-                            __CLASS__ . 'WIDTH', 'Thumbnail height'
+                            __CLASS__ . '.HEIGHT', 'Thumbnail height'
                         )
                     )
                 ]
@@ -186,7 +186,7 @@ class ElementQuickGallery extends ElementContent {
                     ->setAllowedExtensions($this->getAllowedFileTypes())
                     ->setDescription(
                         sprintf(_t(
-                            __CLASS__ . 'ALLOWED_FILE_TYPES',
+                            __CLASS__ . '.ALLOWED_FILE_TYPES',
                             'Allowed file types: %s'
                         ), implode(",", $this->getAllowedFileTypes()))
                     )

--- a/src/Models/Elements/ElementQuickGallery.php
+++ b/src/Models/Elements/ElementQuickGallery.php
@@ -2,7 +2,7 @@
 
 namespace NSWDPC\Elemental\Models\QuickGallery;
 
-use NSWDPC\Elemental\Models\QuickGallery\ElementQuickGalleryController;
+use NSWDPC\Elemental\Controllers\QuickGallery\ElementQuickGalleryController;
 use Bummzack\SortableFile\Forms\SortableUploadField;
 use DNADesign\Elemental\Models\ElementContent;
 use SilverStripe\Assets\Image;

--- a/src/Services/Frontend.php
+++ b/src/Services/Frontend.php
@@ -95,7 +95,12 @@ class Frontend {
         $script = <<<JS
 $(document).ready(function(){
     $('#{$anchor} [data-type="gallery"]').slickLightbox({
-        itemSelector: 'a'
+        itemSelector: 'a',
+        caption: function(element, info) {
+            return $(element).next('p.caption').text()
+        },
+        captionPosition: 'dynamic',
+        lazy: true
     });
 });
 JS;

--- a/src/Services/Frontend.php
+++ b/src/Services/Frontend.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace NSWDPC\Elemental\Services\QuickGallery;
+
+use NSWDPC\Elemental\Models\QuickGallery\ElementQuickGallery;
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\View\Requirements;
+
+/**
+ * Provides a basic frontend using Slick
+ * Apply your own frontend and/or frontend loader using Injector
+ * @author James
+ */
+class Frontend {
+
+    use Configurable;
+
+    use Injectable;
+
+    /**
+     * @var ElementQuickGallery
+     */
+    protected $element;
+
+    /**
+     * Add all requirements
+     * @return void
+     * @param ElementQuickGallery $element
+     */
+    public function addRequirements(ElementQuickGallery $element) {
+        $this->element = $element;
+        if ($this->element->UseJS == 1) {
+
+            Requirements::javascript(
+                'https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js',
+                [
+                    "integrity" => "sha512-XtmMtDEcNz2j7ekrtHvOVR4iwwaD6o/FUJe6+Zq+HgcCsk3kj4uSQQR8weQ2QVj1o0Pk6PwYLohm206ZzNfubg==",
+                    "crossorigin" => "anonymous"
+                ]
+            );
+
+            Requirements::javascript(
+                'https://cdnjs.cloudflare.com/ajax/libs/slick-lightbox/0.2.12/slick-lightbox.min.js',
+                [
+                    "integrity" => "sha512-iSVaq9Huv1kxBDAOH7Il1rwIJD+uspMQC1r4Y73QquhbI2ia+PIXUoS5rBjWjYyD03S8t7gZmON+Dk6yPlWHXw==",
+                    "crossorigin" => "anonymous"
+                ]
+            );
+
+            Requirements::css(
+                'https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.css',
+                'screen',
+                [
+                    "integrity" => "sha512-yHknP1/AwR+yx26cB1y0cjvQUMvEa2PFzt1c9LlS4pRQ5NOTZFWbhBig+X9G9eYW/8m0/4OXNx8pxJ6z57x0dw==",
+                    "crossorigin" => "anonymous"
+                ]
+            );
+            Requirements::css(
+                'https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick-theme.min.css',
+                'screen',
+                [
+                    "integrity" => "sha512-17EgCFERpgZKcm0j0fEq1YCJuyAWdz9KUtv1EjVuaOz8pDnh/0nZxmU6BBXwaaxqoi9PQXnRWqlcDB027hgv9A==",
+                    "crossorigin" => "anonymous"
+                ]
+            );
+            Requirements::css(
+                'https://cdnjs.cloudflare.com/ajax/libs/slick-lightbox/0.2.12/slick-lightbox.css',
+                'screen',
+                [
+                    "integrity" => "sha512-GPEZI1E6wle+Inl8CkTU3Ncgc9WefoWH4Jp8urbxZNbaISy0AhzIMXVzdK2GEf1+OVhA+MlcwPuNve3rL1F9yg==",
+                    "crossorigin" => "anonymous"
+                ]
+            );
+
+            $this->addLoader();
+
+        }
+
+    }
+
+    /**
+     * Adds a loader to apply the frontend
+     * @return void
+     */
+    public function addLoader() {
+
+        if(!$this->element) {
+            // Cannot load if no element defined
+            return;
+        }
+
+        // Apply loaded to this element via its anchor
+        $anchor = $this->element->getAnchor();
+        $script = <<<JS
+$(document).ready(function(){
+    $('#{$anchor} .gallery').slickLightbox({
+        itemSelector: 'a'
+    });
+});
+JS;
+        Requirements::customScript($script, "gallery-{$anchor}");
+
+    }
+
+}

--- a/src/Services/Frontend.php
+++ b/src/Services/Frontend.php
@@ -94,7 +94,7 @@ class Frontend {
         $anchor = $this->element->getAnchor();
         $script = <<<JS
 $(document).ready(function(){
-    $('#{$anchor} .gallery').slickLightbox({
+    $('#{$anchor} [data-type="gallery"]').slickLightbox({
         itemSelector: 'a'
     });
 });

--- a/templates/NSWDPC/Elemental/Models/QuickGallery/ElementQuickGallery.ss
+++ b/templates/NSWDPC/Elemental/Models/QuickGallery/ElementQuickGallery.ss
@@ -1,5 +1,5 @@
 <% include ElementQuickGalleryTitle %>
-<div class="{$ElementStyles}">
+<div class="{$ElementStyles}" data-type="gallery">
     <% loop $SortedImages %>
     <div>
         <a<% if $Title %> title="{$Title.XML}"<% end_if %> href="{$Link}">

--- a/templates/NSWDPC/Elemental/Models/QuickGallery/ElementQuickGallery.ss
+++ b/templates/NSWDPC/Elemental/Models/QuickGallery/ElementQuickGallery.ss
@@ -5,6 +5,11 @@
         <a<% if $Title %> title="{$Title.XML}"<% end_if %> href="{$Link}">
         <% include ElementQuickGalleryImage Width=$Up.ThumbWidth, Height=$Up.ThumbHeight %>
         </a>
+        <% if $Up.ShowCaptions %>
+        <p class="caption">
+            <% if $AltText %>{$AltText}<% else %>{$Title}<% end_if %>
+        </p>
+        <% end_if %>
     </div>
     <% end_loop %>
 </div>


### PR DESCRIPTION
## Changes

+ Provide a configurable, injectable frontend to load the gallery (583881e)
+ Provide some captioning smarts (a46f6c6)
+ Load via data-type (4ec364b)
+ Restrict slickLightbox to the element anchor 
+ Apply image width/height changes - improved default handling, increase defauilt dimensions, allow zero width and height to imply original image loading,  from feat-fields branch (e05e3a4)
+ Provide updated gallery types, deprecate 'carousel' type
+ Remove erroneous debug (e55c331)

